### PR TITLE
Switch to the (sub)layer of the picked tile/prop

### DIFF
--- a/tools/ExtendedPropTool.cpp
+++ b/tools/ExtendedPropTool.cpp
@@ -57,6 +57,10 @@ class ExtendedPropTool : Tool
 				script.editor.set_prop(p.prop_set(), p.prop_group(), p.prop_index(), p.palette());
 				script.editor.set_selected_layer(p.layer());
 				script.editor.set_selected_sub_layer(p.sub_layer());
+				script.show_info_popup(
+					'Prop: ' + p.prop_set() + '.' + p.prop_group() + '.' + p.prop_index() + '|' + p.palette() + '\n' +
+					'Layer: ' + p.layer() + '.' + p.sub_layer(),
+					null, PopupPosition::Below, 2);
 			}
 			else
 			{

--- a/tools/ExtendedPropTool.cpp
+++ b/tools/ExtendedPropTool.cpp
@@ -55,6 +55,8 @@ class ExtendedPropTool : Tool
 				@pick_data = @prop_tool.highlighted_props_list[0];
 				prop@ p = pick_data.prop;
 				script.editor.set_prop(p.prop_set(), p.prop_group(), p.prop_index(), p.palette());
+				script.editor.set_selected_layer(p.layer());
+				script.editor.set_selected_sub_layer(p.sub_layer());
 			}
 			else
 			{

--- a/tools/ExtendedTileTool.cpp
+++ b/tools/ExtendedTileTool.cpp
@@ -75,6 +75,7 @@ class ExtendedTileTool : Tool
 				
 				script.editor.set_tile_sprite(
 					tile.sprite_set(), tile.sprite_tile(), tile.sprite_palette());
+				script.editor.set_selected_layer(layer);
 				script.show_info_popup(
 					'Tile: ' + tile.sprite_set() + '.' +tile.sprite_tile() + '.' +tile.sprite_palette() + '\n' +
 					'Layer: ' + layer,

--- a/tools/ExtendedTileTool.cpp
+++ b/tools/ExtendedTileTool.cpp
@@ -77,7 +77,7 @@ class ExtendedTileTool : Tool
 					tile.sprite_set(), tile.sprite_tile(), tile.sprite_palette());
 				script.editor.set_selected_layer(layer);
 				script.show_info_popup(
-					'Tile: ' + tile.sprite_set() + '.' +tile.sprite_tile() + '.' +tile.sprite_palette() + '\n' +
+					'Tile: ' + tile.sprite_set() + '.' + tile.sprite_tile() + '.' + tile.sprite_palette() + '\n' +
 					'Layer: ' + layer,
 					null, PopupPosition::Below, 2);
 				break;


### PR DESCRIPTION
Normally when I pick a tile/prop, I do it because I want to add more of that tile/prop on the same layer. This avoids having to change layers all the time.

It would also be cool if we could copy the scale, and maybe even the rotation of the prop we are picking. But, the API does not yet support setting those properties.